### PR TITLE
WIP - Refining the way event participants are managed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.oneuponcancer'
-version '0.12.1'
+version '0.12.2'
 
 apply plugin: 'java'
 apply plugin: 'info.solidsoft.pitest'

--- a/src/main/java/org/oneuponcancer/redemption/model/transport/EventAddParticipantRequest.java
+++ b/src/main/java/org/oneuponcancer/redemption/model/transport/EventAddParticipantRequest.java
@@ -1,0 +1,18 @@
+package org.oneuponcancer.redemption.model.transport;
+
+import javax.validation.constraints.Pattern;
+
+public class EventAddParticipantRequest {
+    // Crazy regex from: http://emailregex.com/
+    @Pattern(regexp = "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])",
+            message = "Email addresses must conform to the official email standard.")
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/org/oneuponcancer/redemption/model/transport/EventCreateRequest.java
+++ b/src/main/java/org/oneuponcancer/redemption/model/transport/EventCreateRequest.java
@@ -6,8 +6,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.Size;
 import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 
 @DateRange(startDate = "startDate", endDate = "endDate")
 public class EventCreateRequest {
@@ -24,8 +22,6 @@ public class EventCreateRequest {
     @FutureOrPresent
     @DateTimeFormat(pattern="yyyy-MM-dd'T'HH:mm")
     private Date endDate;
-
-    private List<UUID> participants;
 
     public String getName() {
         return name;
@@ -57,13 +53,5 @@ public class EventCreateRequest {
 
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
-    }
-
-    public List<UUID> getParticipants() {
-        return participants;
-    }
-
-    public void setParticipants(List<UUID> participants) {
-        this.participants = participants;
     }
 }

--- a/src/main/java/org/oneuponcancer/redemption/model/transport/EventEditRequest.java
+++ b/src/main/java/org/oneuponcancer/redemption/model/transport/EventEditRequest.java
@@ -6,8 +6,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.Size;
 import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 
 @DateRange(startDate = "startDate", endDate = "endDate")
 public class EventEditRequest {
@@ -24,8 +22,6 @@ public class EventEditRequest {
     @FutureOrPresent(message = "End date must be in the future.")
     @DateTimeFormat(pattern="yyyy-MM-dd'T'HH:mm")
     private Date endDate;
-
-    private List<UUID> participants;
 
     public String getName() {
         return name;
@@ -57,13 +53,5 @@ public class EventEditRequest {
 
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
-    }
-
-    public List<UUID> getParticipants() {
-        return participants;
-    }
-
-    public void setParticipants(List<UUID> participants) {
-        this.participants = participants;
     }
 }

--- a/src/main/java/org/oneuponcancer/redemption/repository/ParticipantRepository.java
+++ b/src/main/java/org/oneuponcancer/redemption/repository/ParticipantRepository.java
@@ -4,8 +4,10 @@ import org.oneuponcancer.redemption.model.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface ParticipantRepository extends JpaRepository<Participant, UUID> {
+    Optional<Participant> findByEmail(String email);
 }

--- a/src/main/java/org/oneuponcancer/redemption/resource/EventParticipantResource.java
+++ b/src/main/java/org/oneuponcancer/redemption/resource/EventParticipantResource.java
@@ -1,0 +1,110 @@
+package org.oneuponcancer.redemption.resource;
+
+import org.oneuponcancer.redemption.exception.InsufficientPermissionException;
+import org.oneuponcancer.redemption.model.Event;
+import org.oneuponcancer.redemption.model.Participant;
+import org.oneuponcancer.redemption.model.Permission;
+import org.oneuponcancer.redemption.model.transport.EventAddParticipantRequest;
+import org.oneuponcancer.redemption.repository.EventRepository;
+import org.oneuponcancer.redemption.repository.ParticipantRepository;
+import org.oneuponcancer.redemption.service.AuditLogService;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/api/v1/event/{id}/participant")
+public class EventParticipantResource {
+    private EventRepository eventRepository;
+    private ParticipantRepository participantRepository;
+    private AuditLogService auditLogService;
+
+    @Inject
+    public EventParticipantResource(
+            EventRepository eventRepository,
+            ParticipantRepository participantRepository,
+            AuditLogService auditLogService) {
+
+        this.eventRepository = eventRepository;
+        this.participantRepository = participantRepository;
+        this.auditLogService = auditLogService;
+    }
+
+    @RequestMapping(value = "", method = RequestMethod.POST)
+    @ResponseBody
+    public Event addParticipant(@Valid EventAddParticipantRequest eventAddParticipantRequest,
+                                BindingResult bindingResult,
+                                @PathVariable("id") UUID eventId,
+                                Principal principal,
+                                HttpServletRequest request) {
+
+        if (((UsernamePasswordAuthenticationToken)principal).getAuthorities().stream().noneMatch(a -> a.getAuthority().equals(Permission.EDIT_EVENT.name()))) {
+            throw new InsufficientPermissionException("Not allowed to edit events.");
+        }
+
+        if (bindingResult.hasErrors()) {
+            String errorMessages = bindingResult.getAllErrors()
+                    .stream()
+                    .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                    .collect(Collectors.joining("\n"));
+
+            throw new ValidationException(errorMessages);
+        }
+
+        Participant participant = participantRepository
+                .findByEmail(eventAddParticipantRequest.getEmail())
+                .orElseThrow(() -> new NullPointerException("No such participant found."));
+
+        Event event = eventRepository
+                .findById(eventId)
+                .orElseThrow(() -> new NullPointerException("No such event found."));
+
+        event.getParticipants().add(participant);
+
+        Event savedEvent = eventRepository.save(event);
+
+        auditLogService.log(
+                principal.getName(),
+                auditLogService.extractRemoteIp(request),
+                String.format("Added participant to event: %s (%s) -> %s (%s)",
+                        participant.getLastName() + ", " + participant.getFirstName(),
+                        participant.getId(),
+                        event.getName(),
+                        event.getId()));
+
+
+        return savedEvent;
+    }
+
+    @ExceptionHandler(NullPointerException.class)
+    public void handleNotFoundException(NullPointerException ex, HttpServletResponse response) throws Exception {
+        response.sendError(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    }
+
+    @ExceptionHandler(InsufficientPermissionException.class)
+    public void handleInsufficientPermissionException(InsufficientPermissionException ex, HttpServletResponse response) throws IOException {
+        response.sendError(HttpStatus.FORBIDDEN.value(), ex.getMessage());
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public void handleValidationException(ValidationException ex, HttpServletResponse response) throws IOException {
+        response.sendError(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+    }
+}

--- a/src/main/java/org/oneuponcancer/redemption/resource/EventResource.java
+++ b/src/main/java/org/oneuponcancer/redemption/resource/EventResource.java
@@ -2,12 +2,10 @@ package org.oneuponcancer.redemption.resource;
 
 import org.oneuponcancer.redemption.exception.InsufficientPermissionException;
 import org.oneuponcancer.redemption.model.Event;
-import org.oneuponcancer.redemption.model.Participant;
 import org.oneuponcancer.redemption.model.Permission;
 import org.oneuponcancer.redemption.model.transport.EventCreateRequest;
 import org.oneuponcancer.redemption.model.transport.EventEditRequest;
 import org.oneuponcancer.redemption.repository.EventRepository;
-import org.oneuponcancer.redemption.repository.ParticipantRepository;
 import org.oneuponcancer.redemption.service.AuditLogService;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
@@ -36,13 +34,11 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/v1/event")
 public class EventResource {
     private EventRepository eventRepository;
-    private ParticipantRepository participantRepository;
     private AuditLogService auditLogService;
 
     @Inject
-    public EventResource(EventRepository eventRepository, ParticipantRepository participantRepository, AuditLogService auditLogService) {
+    public EventResource(EventRepository eventRepository, AuditLogService auditLogService) {
         this.eventRepository = eventRepository;
-        this.participantRepository = participantRepository;
         this.auditLogService = auditLogService;
     }
 
@@ -78,14 +74,7 @@ public class EventResource {
         event.setDescription(eventCreateRequest.getDescription());
         event.setStartDate(eventCreateRequest.getStartDate());
         event.setEndDate(eventCreateRequest.getEndDate());
-
-        if (eventCreateRequest.getParticipants() != null) {
-            List<Participant> participants = participantRepository.findAllById(eventCreateRequest.getParticipants());
-
-            event.setParticipants(participants);
-        } else {
-            event.setParticipants(Collections.emptyList());
-        }
+        event.setParticipants(Collections.emptyList());
 
         Event savedEvent = eventRepository.save(event);
 
@@ -124,14 +113,6 @@ public class EventResource {
         event.setDescription(eventEditRequest.getDescription());
         event.setStartDate(eventEditRequest.getStartDate());
         event.setEndDate(eventEditRequest.getEndDate());
-
-        if (eventEditRequest.getParticipants() != null) {
-            List<Participant> participants = participantRepository.findAllById(eventEditRequest.getParticipants());
-
-            event.setParticipants(participants);
-        } else {
-            event.setParticipants(Collections.emptyList());
-        }
 
         Event savedEvent = eventRepository.save(event);
 

--- a/src/main/java/org/oneuponcancer/redemption/resource/IndexResource.java
+++ b/src/main/java/org/oneuponcancer/redemption/resource/IndexResource.java
@@ -182,11 +182,8 @@ public class IndexResource {
             throw new InsufficientPermissionException("Not allowed to create events.");
         }
 
-        List<Participant> participants = participantRepository.findAll();
-
         model.addAttribute("version", applicationVersion);
         model.addAttribute("permissions", Permission.values());
-        model.addAttribute("participants", participants);
 
         return "eventcreate";
     }
@@ -202,12 +199,10 @@ public class IndexResource {
                 .findById(uuid)
                 .orElseThrow(() -> new IllegalArgumentException("No event with provided ID"));
 
-        List<Participant> participants = participantRepository.findAll();
-
         model.addAttribute("version", applicationVersion);
         model.addAttribute("permissions", Permission.values());
         model.addAttribute("event", event);
-        model.addAttribute("participants", participants);
+        model.addAttribute("participants", event.getParticipants());
 
         return "eventedit";
     }

--- a/src/main/resources/db/migration/V0007__unique_participant_emails.sql
+++ b/src/main/resources/db/migration/V0007__unique_participant_emails.sql
@@ -1,0 +1,1 @@
+ALTER TABLE participant ADD CONSTRAINT UNIQUE (email);

--- a/src/main/resources/static/css/eventedit.css
+++ b/src/main/resources/static/css/eventedit.css
@@ -3,3 +3,9 @@
     padding: 15px;
     background-color: #383838;
 }
+
+#event-participants-edit-form {
+    margin: 5px;
+    padding: 15px;
+    background-color: #383838;
+}

--- a/src/main/resources/static/js/eventedit.js
+++ b/src/main/resources/static/js/eventedit.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    $("button.btn-primary").click(function() {
+    $("#event-edit-form button.btn-primary").click(function() {
         var form = $("#event-edit-form form");
 
         $.ajax({
@@ -9,7 +9,7 @@ $(document).ready(function() {
         }).done(function() {
             window.location = "/dashboard";
         }).fail(function(jqXHR) {
-            var errorBox = $("#error-box");
+            var errorBox = $("#event-error-box");
 
             errorBox.removeClass("invisible");
             errorBox.find("p").html(jqXHR.responseJSON.message.split("\n").join("<br/>"));
@@ -19,8 +19,35 @@ $(document).ready(function() {
         return false;
     });
 
-    $("button.btn-danger").click(function() {
+    $("#event-edit-form button.btn-danger").click(function() {
         window.location = "/dashboard";
+
+        event.preventDefault();
+        return false;
+    });
+
+    $("#event-participants-edit-form button.btn-primary").click(function() {
+        var form = $("#event-participants-edit-form form");
+        var submittedEmail = $("#event-participant").val();
+
+        $.ajax({
+            url: form.attr("action"),
+            method: "POST",
+            data: form.serialize()
+        }).done(function(event) {
+            var matches = event.participants.filter(p => p.email === submittedEmail);
+
+            if (matches.length > 0) {
+                var participant = matches[0];
+
+                $("#event-participant-table tr:last").after(`<tr><td>${participant.lastName}, ${participant.firstName} (${participant.email})</td><td><button type="submit" class="btn btn-danger" disabled>Remove</button></td></tr>`);
+            }
+        }).fail(function(jqXHR) {
+            var errorBox = $("#event-participant-error-box");
+
+            errorBox.removeClass("invisible");
+            errorBox.find("p").html(jqXHR.responseJSON.message.split("\n").join("<br/>"));
+        });
 
         event.preventDefault();
         return false;

--- a/src/main/resources/templates/eventcreate.ftl
+++ b/src/main/resources/templates/eventcreate.ftl
@@ -35,14 +35,6 @@
                         <label for="">End Date (GMT)</label>
                         <input type="datetime-local" class="form-control" name="endDate" id="event-end-date">
                     </div>
-                    <div class="form-group">
-                        <label for="">Participants</label>
-                        <select multiple="multiple" name="participants" id="event-participants">
-                            <#list participants as participant>
-                                <option value="${participant.id}">${participant.lastName}, ${participant.firstName}</option>
-                            </#list>
-                        </select>
-                    </div>
                     <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <button class="btn btn-danger">Cancel</button>
                     <button class="btn btn-primary">Submit</button>

--- a/src/main/resources/templates/eventedit.ftl
+++ b/src/main/resources/templates/eventedit.ftl
@@ -16,7 +16,7 @@
             <div id="event-edit-form">
                 <h1>Edit Event</h1>
                 <form action="<@spring.url '/api/v1/event/${event.id}'/>" method="post">
-                    <div id="error-box" class="form-group invisible">
+                    <div id="event-error-box" class="form-group invisible">
                         <p class="text-danger"></p>
                     </div>
                     <div class="form-group">
@@ -35,17 +35,36 @@
                         <label for="">End Date (GMT)</label>
                         <input type="datetime-local" class="form-control" name="endDate" id="event-end-date" value="${event.endDate?string["yyyy-MM-dd'T'HH:mm"]}">
                     </div>
-                    <div class="form-group">
-                        <label for="">Participants</label>
-                        <select multiple="multiple" name="participants" id="event-participants">
-                            <#list participants as participant>
-                                <option value="${participant.id}" ${event.participants?seq_contains(participant)?string("selected", "")}>${participant.lastName}, ${participant.firstName}</option>
-                            </#list>
-                        </select>
-                    </div>
                     <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <button class="btn btn-danger">Cancel</button>
                     <button class="btn btn-primary">Submit</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <div id="event-participants-edit-form">
+                <h1>Event Participants</h1>
+                <form action="<@spring.url '/api/v1/event/${event.id}/participant'/>" method="post">
+                    <div id="event-participant-error-box" class="form-group invisible">
+                        <p class="text-danger"></p>
+                    </div>
+                    <div class="form-group">
+                        <label for="">Participants</label>
+                        <table id="event-participant-table">
+                            <tr><th>Participant</th><th>Actions</th></tr>
+                            <#list participants as participant>
+                                <tr><td>${participant.lastName}, ${participant.firstName} (${participant.email})</td><td><button type="submit" class="btn btn-danger" disabled>Remove</button></td></tr>
+                            </#list>
+                        </table>
+                    </div>
+                    <div class="form-group">
+                        <label for="">Add Participant</label>
+                        <input type="text" class="form-control" name="email" id="event-participant" placeholder="Participant Email">
+                    </div>
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+                    <button class="btn btn-primary">Add</button>
                 </form>
             </div>
         </div>

--- a/src/test/java/org/oneuponcancer/redemption/model/transport/EventCreateRequestTest.java
+++ b/src/test/java/org/oneuponcancer/redemption/model/transport/EventCreateRequestTest.java
@@ -4,10 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 
@@ -51,14 +48,5 @@ public class EventCreateRequestTest {
         eventCreateRequest.setEndDate(now);
 
         assertEquals(now, eventCreateRequest.getEndDate());
-    }
-
-    @Test
-    public void testParticipants() {
-        List<UUID> participants = new ArrayList<>();
-
-        eventCreateRequest.setParticipants(participants);
-
-        assertEquals(participants, eventCreateRequest.getParticipants());
     }
 }

--- a/src/test/java/org/oneuponcancer/redemption/model/transport/EventEditRequestTest.java
+++ b/src/test/java/org/oneuponcancer/redemption/model/transport/EventEditRequestTest.java
@@ -52,13 +52,4 @@ public class EventEditRequestTest {
 
         assertEquals(now, eventEditRequest.getEndDate());
     }
-
-    @Test
-    public void testParticipants() {
-        List<UUID> participants = new ArrayList<>();
-
-        eventEditRequest.setParticipants(participants);
-
-        assertEquals(participants, eventEditRequest.getParticipants());
-    }
 }

--- a/src/test/java/org/oneuponcancer/redemption/resource/EventParticipantResourceTest.java
+++ b/src/test/java/org/oneuponcancer/redemption/resource/EventParticipantResourceTest.java
@@ -1,0 +1,176 @@
+package org.oneuponcancer.redemption.resource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.oneuponcancer.redemption.exception.InsufficientPermissionException;
+import org.oneuponcancer.redemption.model.Event;
+import org.oneuponcancer.redemption.model.Participant;
+import org.oneuponcancer.redemption.model.Permission;
+import org.oneuponcancer.redemption.model.transport.EventAddParticipantRequest;
+import org.oneuponcancer.redemption.repository.EventRepository;
+import org.oneuponcancer.redemption.repository.ParticipantRepository;
+import org.oneuponcancer.redemption.service.AuditLogService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ValidationException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class EventParticipantResourceTest {
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private AuditLogService auditLogService;
+
+    @Mock
+    private BindingResult bindingResult;
+
+    @Mock
+    private UsernamePasswordAuthenticationToken principal;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    private String participantEmail = "mark@twain.com";
+    private Participant participant = new Participant();
+    private UUID eventId = UUID.randomUUID();
+    private Event event = new Event();
+
+    private EventParticipantResource resource;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        when(eventRepository.save(any(Event.class))).thenAnswer(i -> {
+            Event event = i.getArgument(0);
+
+            if (event.getId() == null) {
+                event.setId(UUID.randomUUID());
+            }
+
+            return event;
+        });
+
+        participant.setId(UUID.randomUUID());
+        participant.setEmail(participantEmail);
+        participant.setFirstName("Mark");
+        participant.setLastName("Twain");
+
+        event.setId(eventId);
+        event.setName("Test Event");
+        event.setParticipants(new ArrayList<>());
+
+        when(principal.getName()).thenReturn("Admin");
+        when(auditLogService.extractRemoteIp(any(HttpServletRequest.class))).thenReturn("500.501.502.503");
+        when(participantRepository.findByEmail(eq(participantEmail))).thenReturn(Optional.of(participant));
+        when(eventRepository.findById(eq(event.getId()))).thenReturn(Optional.of(event));
+        when(principal.getAuthorities()).thenReturn(Collections.singletonList(new SimpleGrantedAuthority(Permission.EDIT_EVENT.name())));
+
+        resource = new EventParticipantResource(
+                eventRepository,
+                participantRepository,
+                auditLogService
+        );
+    }
+
+    @Test
+    public void testAddParticipant() {
+        EventAddParticipantRequest request = new EventAddParticipantRequest();
+
+        request.setEmail(participantEmail);
+
+        Event result = resource.addParticipant(
+                request,
+                bindingResult,
+                eventId,
+                principal,
+                httpServletRequest);
+
+        assertTrue(result.getParticipants().contains(participant));
+
+        verify(auditLogService).log(anyString(), anyString(), contains("Added participant"));
+    }
+
+    @Test(expected = InsufficientPermissionException.class)
+    public void testAddParticipantNoPermission() {
+        EventAddParticipantRequest request = new EventAddParticipantRequest();
+
+        request.setEmail(participantEmail);
+
+        when(principal.getAuthorities()).thenReturn(Collections.emptyList());
+
+        resource.addParticipant(
+                request,
+                bindingResult,
+                eventId,
+                principal,
+                httpServletRequest);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testAddParticipantMalformedEmail() {
+        String notAnEmail = "i-am-not-an-email-address";
+        EventAddParticipantRequest request = new EventAddParticipantRequest();
+        ObjectError objectError = mock(ObjectError.class);
+
+        request.setEmail(notAnEmail);
+
+        when(objectError.getDefaultMessage()).thenReturn("Not a valid email address.");
+        when(bindingResult.hasErrors()).thenReturn(true);
+        when(bindingResult.getAllErrors()).thenReturn(Collections.singletonList(objectError));
+
+        resource.addParticipant(
+                request,
+                bindingResult,
+                eventId,
+                principal,
+                httpServletRequest);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testAddParticipantNoSuchParticipant() {
+        String nonExistentEmail = "no.such@email.address";
+        EventAddParticipantRequest request = new EventAddParticipantRequest();
+
+        request.setEmail(nonExistentEmail);
+
+        resource.addParticipant(
+                request,
+                bindingResult,
+                eventId,
+                principal,
+                httpServletRequest);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testAddParticipantNoSuchEvent() {
+        UUID badEventId = UUID.randomUUID();
+        EventAddParticipantRequest request = new EventAddParticipantRequest();
+
+        request.setEmail(participantEmail);
+
+        resource.addParticipant(
+                request,
+                bindingResult,
+                badEventId,
+                principal,
+                httpServletRequest);
+    }
+}

--- a/src/test/java/org/oneuponcancer/redemption/resource/IndexResourceTest.java
+++ b/src/test/java/org/oneuponcancer/redemption/resource/IndexResourceTest.java
@@ -397,11 +397,8 @@ public class IndexResourceTest {
 
         assertEquals("eventcreate", result);
 
-        verify(participantRepository).findAll();
-
         verify(model).addAttribute(eq("version"), eq(APPLICATION_VERSION));
         verify(model).addAttribute(eq("permissions"), any(Permission[].class));
-        verify(model).addAttribute(eq("participants"), anyIterable());
     }
 
     @Test(expected = InsufficientPermissionException.class)
@@ -414,7 +411,6 @@ public class IndexResourceTest {
         UUID uuid = UUID.randomUUID();
 
         when(eventRepository.findById(eq(uuid))).thenReturn(Optional.of(event));
-        when(participantRepository.findAll()).thenReturn(generateParticipants());
         when(principal.getAuthorities()).thenReturn(Collections.singletonList(
                 new SimpleGrantedAuthority(Permission.EDIT_EVENT.name())
         ));
@@ -422,8 +418,6 @@ public class IndexResourceTest {
         String result = indexResource.editEvent(principal, model, uuid.toString());
 
         assertEquals("eventedit", result);
-
-        verify(participantRepository).findAll();
 
         verify(model).addAttribute(eq("version"), eq(APPLICATION_VERSION));
         verify(model).addAttribute(eq("permissions"), any(Permission[].class));


### PR DESCRIPTION
* Removed the multi-select box from create and edit screens
* You must create the event without participants, then edit to add them
* Participant emails are now required to be unique in the database
* Edit screen allows adding each participant by email address
* Remove doesn't work yet, that'll be the next PR

Event edits no longer include changes to participants. Each participant change will be a separate REST call and happen immediately. When there are many participants in the database and many participating in an event, this strategy will be much more scalable than the multi-select box.

This would be a good argument for moving to something like Angular or React because we will have problems when several people are changing participants on an event at the same time. Right now, if someone else changes the list, your view of it won't update until you reload the page. Some of those more modern frameworks provide real time updates when the underlying data changes, so you'd be able to see changes from other users immediately as they happen. That's a big lift that I'll save for post-MVP.